### PR TITLE
Rework the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,50 +1,15 @@
+---
 name: Build and Publish the mailserver Docker Image to GHCR.io
-
-# Manually-triggered action to build the latest version (or optionally, if provided, a release tag)
-#   of mailserver.
-
 on:
-  workflow_dispatch:
-    inputs:
-      version_tag:
-        description: Optional version tag to build. Defaults to latest main.
-        required: false
-      tag_as_latest:
-        description: Also tag image as latest (in addition to tag supplied / computed).
-        type: boolean
-        default: 0
+  push:
+    tags:
+      - '*'
 
 jobs:
-  build_and_publish_image:
+  build_image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          path: mailserver
-          fetch-depth: 0
-
-      - name: Optionally Check Out Tag
-        if: ${{ inputs.version_tag }}
-        # work around https://github.com/actions/runner/issues/665
-        shell: bash
-        env:
-          VERSION_TAG: ${{ inputs.version_tag }}
-        run: |
-          cd mailserver
-          git checkout "mailserver-$VERSION_TAG"
-
-      - name: Grok image tag
-        run: |
-          cd mailserver
-          git describe --tags | tee SRC_TAG
-          echo "ghcr.io/t-lo/mailserver:$(cat SRC_TAG)" | tee IMAGE_TAG
-
-      - name: Build the docker image
-        run: |
-          cd mailserver
-          tag=$(cat IMAGE_TAG)
-          docker build -t "$(cat IMAGE_TAG)" .
-
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
@@ -52,12 +17,39 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Image
-        run: |
-          docker push "$(cat mailserver/IMAGE_TAG)"
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ghcr.io/${{ github.repository }}
 
-      - name: Optionally Tag Image as Latest
-        if: ${{ inputs.tag_as_latest }}
-        run: |
-          docker tag "$(cat mailserver/IMAGE_TAG)" ghcr.io/t-lo/mailserver:latest
-          docker push ghcr.io/t-lo/mailserver:latest
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  do_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get release version
+        id: version
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v3
+
+      # Build the tarball
+      - run: |
+          echo "${{ steps.version.outputs.tag }}" > VERSION
+          tar czvf "${{ steps.version.outputs.tag }}.tar.gz" -T release-files.txt
+      # Create the release
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          files: |
+            ${{ steps.version.outputs.tag }}.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,arm'
+
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
This works on #9

On new tags, it now
* Builds the docker image, and pushes it to the registry
* Collects all required files into a tar.gz
* Creates a release, with that tar.gz attached

There is still some aditional setup required, specifically a secret with a GitHub token that is allowed to create releases needs to be created. The secret should be named `GITHUB_TOKEN`